### PR TITLE
Added ability to shape music genre with chunks.

### DIFF
--- a/data/music/regions/asgarnia.json
+++ b/data/music/regions/asgarnia.json
@@ -37,6 +37,12 @@
     "parent": "Asgarnia",
     "comment": "City specific of both + rogues den",
     "isActive": true,
+    "chunkIds": [
+      5885272,
+      5885264,
+      5885280,
+      5868888
+    ],
     "regionIds": [
       12109,
       11575,

--- a/data/music/regions/other.json
+++ b/data/music/regions/other.json
@@ -589,6 +589,12 @@
     "genre": "Daemonheim, Dungeoneering",
     "comment": "",
     "isActive": true,
+    "chunkIds": [
+      5868880,
+      5852496,
+      5852488,
+      5868872
+    ],
     "regionIds": [
       13627,
       13883,

--- a/src/main/java/com/rs/game/World.java
+++ b/src/main/java/com/rs/game/World.java
@@ -300,7 +300,7 @@ public final class World {
 		int regionId = entity.getRegionId();
 		if (entity.getLastRegionId() != regionId || entity.isForceUpdateEntityRegion()) {
 			if (entity instanceof Player player) {
-				if(Settings.getConfig().isDebug() && player.hasStarted() && Music.getGenre(regionId) == null
+				if(Settings.getConfig().isDebug() && player.hasStarted() && Music.getGenre(player) == null
                         && !(World.getRegion(player.getRegionId()) instanceof DynamicRegion))
 					player.sendMessage(regionId + " has no music genre!");
 				if (entity.getLastRegionId() > 0)
@@ -322,8 +322,8 @@ public final class World {
                  * if there is no controller and the region and playing genres don't match, play a song
                  * same if there is a controller but check if the controller allows region play.
                  */
-				if(player.hasStarted() && (Music.getGenre(regionId) == null || player.getMusicsManager().getPlayingGenre() == null
-                        || !player.getMusicsManager().getPlayingGenre().matches(Music.getGenre(regionId)))) {//tested, looks good.
+				if(player.hasStarted() && (Music.getGenre(player) == null || player.getMusicsManager().getPlayingGenre() == null
+                        || !player.getMusicsManager().getPlayingGenre().matches(Music.getGenre(player)))) {//tested, looks good.
                     if (player.getControllerManager().getController() == null) {
                         player.getMusicsManager().nextAmbientSong();
                     } else if (player.getControllerManager().getController().playAmbientOnControllerRegionEnter() && !player.getDungManager().isInsideDungeon()) { //if we start the dungeon controller before the region enter we can get rid of that inside dungeon thing.

--- a/src/main/java/com/rs/game/content/commands/debug/Debug.java
+++ b/src/main/java/com/rs/game/content/commands/debug/Debug.java
@@ -43,16 +43,19 @@ import com.rs.plugin.events.ButtonClickEvent;
 import com.rs.plugin.events.EnterChunkEvent;
 import com.rs.plugin.handlers.ButtonClickHandler;
 import com.rs.plugin.handlers.EnterChunkHandler;
+import com.rs.utils.music.Music;
 
 
 @PluginEventHandler
 public class Debug {
-
+	private static boolean musicMoveOn = false;
 	public static EnterChunkHandler handleTempleChunks = new EnterChunkHandler() {
 		@Override
 		public void handle(EnterChunkEvent e) {
 			if (!Settings.getConfig().isDebug())
 				return;
+			if(musicMoveOn && e.getPlayer() != null && e.getPlayer().hasStarted())
+				e.getPlayer().sendMessage("Region: " + e.getPlayer().getRegionId() + ", Chunk: " + e.getChunkId() + ", Genre: " + Music.getGenre(e.getPlayer()).getGenreName());
 			if (e.getEntity() instanceof Player player)
 				if (player.getNSV().getB("visChunks") && player.hasStarted()) {
 					player.devisualizeChunk(e.getEntity().getLastChunkId());
@@ -83,6 +86,10 @@ public class Debug {
 		//		Commands.add(Rights.PLAYER, "example [arg1 (optionalArg2)]", "This is an example command to replicate.", (p, args) -> {
 		//
 		//		});
+
+		Commands.add(Rights.ADMIN, "shapemusic", "Starts showing music shape.", (p, args) -> {
+			musicMoveOn = !musicMoveOn;
+		});
 
 		Commands.add(Rights.PLAYER, "coords,getpos,mypos,pos,loc", "Gets the coordinates for the tile.", (p, args) -> {
 			p.sendMessage("Coords: " + p.getX() + "," + p.getY() + "," + p.getPlane() + ", regionId: " + p.getRegionId() + ", chunkX: " + p.getChunkX() + ", chunkY: " + p.getChunkY());

--- a/src/main/java/com/rs/game/content/controllers/Controller.java
+++ b/src/main/java/com/rs/game/content/controllers/Controller.java
@@ -82,7 +82,7 @@ public abstract class Controller {
 	 * @return
 	 */
     public Genre getGenre() {
-        return Music.getGenre(player.getRegionId());
+        return Music.getGenre(player);
     }
 
 	/**

--- a/src/main/java/com/rs/game/model/entity/player/managers/MusicsManager.java
+++ b/src/main/java/com/rs/game/model/entity/player/managers/MusicsManager.java
@@ -336,7 +336,7 @@ public final class MusicsManager {
      */
     private void pickAmbientSong() {
         playingGenre = player.getControllerManager().getController() == null ?
-                Music.getGenre(player.getRegionId()) : player.getControllerManager().getController().getGenre();
+                Music.getGenre(player) : player.getControllerManager().getController().getGenre();
         if (playingGenre == null) {
 			playingMusic = NULL_SOUND_TRACK;//don't play music.
 			return;
@@ -417,7 +417,7 @@ public final class MusicsManager {
         settedMusic = false;
         if (playingMusic != requestMusicId)
             playSongWithoutUnlocking(requestMusicId);
-        playingGenre = Music.getGenre(player.getRegionId());
+        playingGenre = Music.getGenre(player);
     }
 
     public void forcePlayMusic(int musicId) {

--- a/src/main/java/com/rs/utils/music/Genre.java
+++ b/src/main/java/com/rs/utils/music/Genre.java
@@ -12,6 +12,7 @@ public class Genre {
 	private String parent;
 	private String comment;
 	private boolean isActive;
+	private int[] chunkIds;
 	private int[] regionIds;
 	private int[] songs;
 
@@ -29,6 +30,12 @@ public class Genre {
 
 	public boolean isActive() {
 		return isActive;
+	}
+
+	public int[] getChunkIds() {
+		if(chunkIds == null)
+			return new int[0];
+		return chunkIds;
 	}
 
 	public int[] getRegionIds() {


### PR DESCRIPTION
Allows ability to shape which genre is playing based on chunk. Does not refresh or update or even do any processing upon chunk entry. It only changes what genre plays next.
![image](https://user-images.githubusercontent.com/27308928/175786591-0574c18b-de29-4597-ad85-1d780a2400c4.png)

Also added a debug handler for shaping genres
![image](https://user-images.githubusercontent.com/27308928/175786626-0a096cba-8aa3-48fe-8afc-6764b4501943.png)
Only on debug and only when the admin toggles it.
![image](https://user-images.githubusercontent.com/27308928/175786733-94e82b9d-559a-40b8-b8d9-092f1d1d976c.png)
This will allow shaping sub-locations like White Wolf Mountain, Ports & shape regions to fit the location when the region ids overlap.