### PR TITLE
Update wilderness combat level.

### DIFF
--- a/src/main/java/com/rs/game/content/world/areas/wilderness/WildernessController.java
+++ b/src/main/java/com/rs/game/content/world/areas/wilderness/WildernessController.java
@@ -85,14 +85,14 @@ public class WildernessController extends Controller {
 		if (target instanceof NPC)
 			return true;
 		Player p2 = (Player) target;
-		if (Math.abs(player.getSkills().getCombatLevel() - p2.getSkills().getCombatLevel()) > getWildLevel())
+		if (Math.abs(player.getSkills().getCombatLevel() - p2.getSkills().getCombatLevel()) > Math.min(player.getPvpCombatLevelThreshhold(), p2.getPvpCombatLevelThreshhold()))
 			return false;
 		return true;
 	}
 
 	@Override
 	public boolean processMagicTeleport(WorldTile toTile) {
-		if ((getWildLevel() > 20) || player.hasEffect(Effect.TELEBLOCK)) {
+		if (getWildLevel() > 20 || player.hasEffect(Effect.TELEBLOCK)) {
 			player.sendMessage("A mysterious force prevents you from teleporting.");
 			return false;
 		}
@@ -231,6 +231,7 @@ public class WildernessController extends Controller {
 		} else if (!showingSkull && isAtWild && !isAtWildSafe) {
 			showingSkull = true;
 			player.setCanPvp(true);
+			player.setPvpCombatLevelThreshhold(getWildLevel());
 			showSkull();
 			player.getAppearance().generateAppearanceData();
 		} else if (showingSkull && (isAtWildSafe || !isAtWild))
@@ -264,8 +265,7 @@ public class WildernessController extends Controller {
 	}
 
 	public static final boolean isAtWild(WorldTile tile) {// TODO fix this
-		return (tile.getX() >= 3011 && tile.getX() <= 3132 && tile.getY() >= 10052 && tile.getY() <= 10175) // fortihrny
-				// dungeon
+		return (tile.getX() >= 3011 && tile.getX() <= 3132 && tile.getY() >= 10052 && tile.getY() <= 10175)
 				|| (tile.getX() >= 2940 && tile.getX() <= 3395 && tile.getY() >= 3525 && tile.getY() <= 4000)
 				|| (tile.getX() >= 3078 && tile.getX() <= 3139 && tile.getY() >= 9923 && tile.getY() <= 10002)
 				|| (tile.getX() >= 3264 && tile.getX() <= 3279 && tile.getY() >= 3279 && tile.getY() <= 3672)

--- a/src/main/java/com/rs/game/model/entity/player/Appearance.java
+++ b/src/main/java/com/rs/game/model/entity/player/Appearance.java
@@ -104,6 +104,8 @@ public class Appearance {
 
 	public void generateAppearanceData() {
 		OutputStream stream = new OutputStream();
+		boolean pvpArea = World.isPvpArea(player);
+		boolean showSkillTotal = player.getTempAttribs().getB("showSkillTotal") && !pvpArea;
 		if (glowRed && player.getNextBodyGlow() == null)
 			player.setNextBodyGlow(new BodyGlow(90, 0, 0, 0, 255));
 		int flag = 0;
@@ -111,7 +113,7 @@ public class Appearance {
 			flag |= 0x1;
 		if (transformedNpcId >= 0 && NPCDefinitions.getDefs(transformedNpcId).aBool4872)
 			flag |= 0x2;
-		if (player.getTempAttribs().getB("showSkillTotal") && !World.isPvpArea(player))
+		if (showSkillTotal)
 			flag |= 0x4;
 		if (title != 0 || player.getTitle() != null)
 			flag |= isTitleAfter(title) || player.isTitleAfter() ? 0x80 : 0x40; // after/before
@@ -198,13 +200,12 @@ public class Appearance {
 
 		stream.writeShort(getRenderEmote());
 		stream.writeString(player.getDisplayName());
-		boolean pvpArea = World.isPvpArea(player);
 		stream.writeByte(pvpArea ? player.getSkills().getCombatLevel() : player.getSkills().getCombatLevelWithSummoning());
-		if (player.getTempAttribs().getB("showSkillTotal") && !pvpArea)
+		if (showSkillTotal)
 			stream.writeShort(player.getSkills().getTotalLevel());
 		else {
 			stream.writeByte(pvpArea ? player.getSkills().getCombatLevelWithSummoning() : 0);
-			stream.writeByte(-1);
+			stream.writeByte(player.getPvpCombatLevelThreshhold());
 		}
 		stream.writeByte(transformedNpcId >= 0 ? 1 : 0);
 		if (transformedNpcId >= 0) {

--- a/src/main/java/com/rs/game/model/entity/player/Player.java
+++ b/src/main/java/com/rs/game/model/entity/player/Player.java
@@ -203,6 +203,7 @@ public class Player extends Entity {
 	public transient long dyingTime = 0;
 	public transient long spellDelay = 0;
 	public transient boolean disconnected = false;
+	private transient int pvpCombatLevelThreshhold = -1;
 	private transient String[] playerOptions = new String[10];
 
 	private int hw07Stage;
@@ -2478,7 +2479,7 @@ public class Player extends Entity {
 	}
 
 	public void setCanPvp(boolean canPvp) {
-		setCanPvp(canPvp, false);
+		setCanPvp(canPvp, true);
 	}
 
 	public PrayerManager getPrayer() {
@@ -4391,5 +4392,14 @@ public class Player extends Entity {
 
 	public void setTileMan(boolean tileMan) {
 		this.tileMan = tileMan;
+	}
+
+	public int getPvpCombatLevelThreshhold() {
+		return pvpCombatLevelThreshhold;
+	}
+
+	public void setPvpCombatLevelThreshhold(int pvpCombatLevelThreshhold) {
+		this.pvpCombatLevelThreshhold = pvpCombatLevelThreshhold;
+		getAppearance().generateAppearanceData();
 	}
 }


### PR DESCRIPTION
Adjust PVP attack threshhold visual indicator (players who are attackable will have usual colored combat level text while players outside your combat bracket will appear as just white text in pvp areas)
Make 'Attack' always the top option on players in PVP areas